### PR TITLE
(step-02) Add missing ViewerQueries headstart code

### DIFF
--- a/branch-step-02/src/index.js
+++ b/branch-step-02/src/index.js
@@ -10,6 +10,8 @@ Relay.injectNetworkLayer(
   new Relay.DefaultNetworkLayer('https://api.graph.cool/relay/v1/__PROJECT_ID__')
 )
 
+const ViewerQueries = { viewer: () => Relay.QL`query { viewer }` }
+
 ReactDOM.render(
   <Router
     forceFetch


### PR DESCRIPTION
The docs mention the following in the 'Exercise 2' section:

> To give you a headstart, we already defined ViewerQueries in index.js.

However, this bit of code is not in the `step-02` branch. This PR fixes that!