### PR TITLE
Defined ViewerQueries as mentioned in the tutorial

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,8 @@ Relay.injectNetworkLayer(
   new Relay.DefaultNetworkLayer('https://api.graph.cool/relay/v1/__PROJECT_ID__')
 )
 
+const ViewerQueries = { viewer: () => Relay.QL`query { viewer }` }
+
 ReactDOM.render(
   <Router
     forceFetch


### PR DESCRIPTION
In the tutorial for step-02 it says "To give you a headstart, we already defined ViewerQueries in index.js." but they were not defined yet. (https://www.learnrelay.org/queries/containers-fragments)